### PR TITLE
3: Fixed the paths

### DIFF
--- a/Demo/AppSrc/EnumPrinters.vw
+++ b/Demo/AppSrc/EnumPrinters.vw
@@ -13,8 +13,6 @@ Use cPrinterJobsHandler.pkg
 Use cPrinterFormsHandler.pkg
 Use cPrinterPortsHandler.pkg
 
-Use Classes\cDateTimeHandler.pkg
-
 Use PrinterInfoDialog.dg
 Use DriverInfoDialog.dg
 Use cCJGrid.pkg

--- a/Demo/Printing Demo.sws
+++ b/Demo/Printing Demo.sws
@@ -10,4 +10,4 @@ Project0=TestLibrary.Src
 Project1=PrinterReady.src
 [Libraries]
 Lib1=..\Library\Printing.sws
-Lib2=..\..\DateTime\Library\DateTime.sws
+

--- a/Library/Printing.sws
+++ b/Library/Printing.sws
@@ -5,4 +5,4 @@ ConfigFile=.\Programs\Config.ws
 [Conditionals]
 Is$WebApp=False
 [Libraries]
-Lib1=..\Libraries\DateAndTime\DateTime.sws
+Lib1=Libraries\DateAndTime\Library\DateTime.sws


### PR DESCRIPTION
- Removed the cDateTimeHandler USE statement from EnumPrinters.vw as it needs to be provided over the library instead of the demo app
- Fixed the path to the DateTime library inside the library sws file